### PR TITLE
Pretty printing for messy numbers

### DIFF
--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -39,7 +39,7 @@ repl.on('line', (commands: string) => {
     if (remainingFraction !== 0) {
       const stringyShiftedResult = Math.round(shiftedResult).toString();
       const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
-      const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES);
+      const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES).replace(/0+$/, '');
       const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
 
       console.log(stringyResult);

--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -3,6 +3,10 @@
 import Readline from 'node:readline';
 import RPN from './lib/rpn';
 
+// Constants
+
+const DECIMAL_PLACES = 2;
+
 // Initialize data model
 
 let stack = RPN.initialModel;
@@ -29,7 +33,20 @@ repl.on('line', (commands: string) => {
   }
   else {
     stack = newStack;
-    console.log(stack.first());
+    const shiftedResult = (stack.first() ?? 0) * (10 ** DECIMAL_PLACES);
+    const remainingFraction = shiftedResult % 1;
+
+    if (remainingFraction !== 0) {
+      const stringyShiftedResult = (shiftedResult - remainingFraction).toString();
+      const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
+      const fractionalPart = stringyShiftedResult.slice(wholePart.length);
+      const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
+
+      console.log(stringyResult);
+    }
+    else {
+      console.log(stack.first());
+    }
   }
 
   repl.prompt();

--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -21,19 +21,26 @@ const DECIMAL_PLACES = 2;
 const DECIMAL_SHIFT_FACTOR = 10 ** DECIMAL_PLACES;
 
 function toPrettyPrintNumber(n: number): string {
-  const shiftedResult = n * DECIMAL_SHIFT_FACTOR;
-  const remainingFraction = shiftedResult % 1;
+  const shiftedN = n * DECIMAL_SHIFT_FACTOR;
+  const remainder = shiftedN % 1;
 
-  if (remainingFraction !== 0) {
-    const stringyShiftedResult = Math.round(shiftedResult).toString();
-    const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
-    const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES).replace(/0+$/, '');
-    const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
-
-    return stringyResult;
+  if (remainder === 0) {
+    return n.toString();
   }
   else {
-    return n.toString();
+    const digits = Math.round(shiftedN).toString();
+    const whole = digits.slice(0, -DECIMAL_PLACES);
+    const fraction = digits.slice(-DECIMAL_PLACES).replace(/0+$/, '');
+
+    const printedWhole = whole !== ''
+      ? whole
+      : '0';
+
+    const printedFraction = fraction !== ''
+      ? `.${fraction}`
+      : '';
+
+    return `${printedWhole}${printedFraction}`;
   }
 }
 

--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -37,7 +37,7 @@ repl.on('line', (commands: string) => {
     const remainingFraction = shiftedResult % 1;
 
     if (remainingFraction !== 0) {
-      const stringyShiftedResult = (shiftedResult - remainingFraction).toString();
+      const stringyShiftedResult = Math.round(shiftedResult).toString();
       const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
       const fractionalPart = stringyShiftedResult.slice(wholePart.length);
       const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;

--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -3,10 +3,6 @@
 import Readline from 'node:readline';
 import RPN from './lib/rpn';
 
-// Constants
-
-const DECIMAL_PLACES = 2;
-
 // Initialize data model
 
 let stack = RPN.initialModel;
@@ -18,6 +14,28 @@ const repl = Readline.createInterface({
   output: process.stdout,
   prompt: '> ',
 });
+
+// Transform possibly messy numbers into nice strings for the REPL
+
+const DECIMAL_PLACES = 2;
+const DECIMAL_SHIFT_FACTOR = 10 ** DECIMAL_PLACES;
+
+function toPrettyPrintNumber(n: number): string {
+  const shiftedResult = n * DECIMAL_SHIFT_FACTOR;
+  const remainingFraction = shiftedResult % 1;
+
+  if (remainingFraction !== 0) {
+    const stringyShiftedResult = Math.round(shiftedResult).toString();
+    const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
+    const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES).replace(/0+$/, '');
+    const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
+
+    return stringyResult;
+  }
+  else {
+    return n.toString();
+  }
+}
 
 // Process input as we get it, line by line
 
@@ -33,20 +51,7 @@ repl.on('line', (commands: string) => {
   }
   else {
     stack = newStack;
-    const shiftedResult = (stack.first() ?? 0) * (10 ** DECIMAL_PLACES);
-    const remainingFraction = shiftedResult % 1;
-
-    if (remainingFraction !== 0) {
-      const stringyShiftedResult = Math.round(shiftedResult).toString();
-      const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
-      const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES).replace(/0+$/, '');
-      const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
-
-      console.log(stringyResult);
-    }
-    else {
-      console.log(stack.first());
-    }
+    console.log(toPrettyPrintNumber(stack.first() ?? 0));
   }
 
   repl.prompt();

--- a/src/rpn-calc.ts
+++ b/src/rpn-calc.ts
@@ -39,7 +39,7 @@ repl.on('line', (commands: string) => {
     if (remainingFraction !== 0) {
       const stringyShiftedResult = Math.round(shiftedResult).toString();
       const wholePart = stringyShiftedResult.slice(0, -DECIMAL_PLACES);
-      const fractionalPart = stringyShiftedResult.slice(wholePart.length);
+      const fractionalPart = stringyShiftedResult.slice(-DECIMAL_PLACES);
       const stringyResult = `${wholePart === '' ? '0' : wholePart}.${fractionalPart}`;
 
       console.log(stringyResult);


### PR DESCRIPTION
IEEE-754 floats are good in the sense they allow for quick arithmetic on fractional numbers. This comes at the cost of some values causing rounding errors. To make the output of these messy numbers more human-friendly for the REPL, we run the numbers through a function that makes them nice, pleasing decimal strings that are rounded to the number of decimal places specified by `DECIMAL_PLACES`.

This feature was started in the second phase interview. 5579adda27dc3043feb31306a0e8ebab9a94284f is the verbatim solution that was programmed on the fly during the interview. It had an error in how it decided to round the number; that is to say, it truncated instead of rounding. This was quickly fixed after the interview, and a number of refactors were performed thereafter to make the code nicer to read and work with.